### PR TITLE
chore: Sync issues and project

### DIFF
--- a/.github/workflows/issue.yaml
+++ b/.github/workflows/issue.yaml
@@ -1,0 +1,12 @@
+on:
+  issues:
+    types: [opened]
+jobs:
+  createCard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create or Update Project Card
+        uses: peter-evans/create-or-update-project-card@v1
+        with:
+          project-name: "디자인패턴 팀플 - 팀 10"
+          column-name: "Todo"


### PR DESCRIPTION
- repo 에 issue 를 만들면 자동으로 Project 에 추가해주는 액션입니다.
- update 여부는 반영되지 않으며, 새롭게 생성되는 issue만 project 에 추가됩니다.

---
- 참고자료 : [stackoverflow - github auto assign issue to project](https://stackoverflow.com/questions/62530078/github-auto-assign-issue-to-project)