### PR TITLE
feat: display current speed bar

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -21,5 +21,6 @@ jobs:
         uses: github/super-linter@v4
         env:
           VALIDATE_ALL_CODEBASE: false
+          VALIDATE_JAVA: false
           DEFAULT_BRANCH: master
           GITHUB_TOKEN: ${{ secrets.PAT }}

--- a/src/main/java/com/holub/life/Life.java
+++ b/src/main/java/com/holub/life/Life.java
@@ -1,6 +1,8 @@
 package com.holub.life;
 
 import com.holub.system.Clock;
+import com.holub.system.Clock.Listener;
+import com.holub.system.TickSystem;
 import com.holub.system.Universe;
 import com.holub.ui.UniversePanel;
 import com.holub.ui.menu.ClockMenuItem;
@@ -26,7 +28,8 @@ public final class Life extends JFrame {
     MenuSite menuSite = new MenuSite();
     menuSite.establish(this);
     UniversePanel universePanel = new UniversePanel(universe, menuSite);
-    ClockMenuItem clockMenu = new ClockMenuItem(clock);
+    TickSystem tickSystem = new TickSystem(clock);
+    ClockMenuItem clockMenu = new ClockMenuItem(tickSystem);
     menuSite.register(clockMenu);
 
     setDefaultCloseOperation(EXIT_ON_CLOSE);

--- a/src/main/java/com/holub/life/Life.java
+++ b/src/main/java/com/holub/life/Life.java
@@ -4,6 +4,7 @@ import com.holub.system.Clock;
 import com.holub.system.Clock.Listener;
 import com.holub.system.TickSystem;
 import com.holub.system.Universe;
+import com.holub.ui.StatusBar;
 import com.holub.ui.UniversePanel;
 import com.holub.ui.menu.ClockMenuItem;
 import com.holub.ui.menu.MenuSite;
@@ -32,9 +33,12 @@ public final class Life extends JFrame {
     ClockMenuItem clockMenu = new ClockMenuItem(tickSystem);
     menuSite.register(clockMenu);
 
+    StatusBar statusBar = new StatusBar();
+    tickSystem.attach(statusBar);
     setDefaultCloseOperation(EXIT_ON_CLOSE);
     getContentPane().setLayout(new BorderLayout());
     getContentPane().add(universePanel, BorderLayout.CENTER);
+    getContentPane().add(statusBar, BorderLayout.SOUTH);
 
     pack();
     setVisible(true);

--- a/src/main/java/com/holub/system/TickSystem.java
+++ b/src/main/java/com/holub/system/TickSystem.java
@@ -1,0 +1,58 @@
+package com.holub.system;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class TickSystem {
+  final Clock clock;
+  Map<String, Integer> tickMap;
+  /**
+   *
+   */
+  private static final int AGONIZING_MS = 500;
+  /**
+   *
+   */
+  private static final int SLOW_MS = 150;
+  /**
+   *
+   */
+  private static final int MEDIUM_MS = 70;
+  /**
+   *
+   */
+  private static final int FAST_MS = 30;
+  /**
+   *
+   */
+
+  public TickSystem(final Clock c) {
+    clock = c;
+    tickMap = new HashMap<>();
+    tickMap.put("Agonizing", AGONIZING_MS); // agonizing
+    tickMap.put("Slow", SLOW_MS); // slow
+    tickMap.put("Medium", MEDIUM_MS); // medium
+    tickMap.put("Fast", FAST_MS); // fast
+  }
+
+  public List<String> getSupportedSpeeds() {
+    return tickMap.keySet().stream()
+        .sorted(Comparator.comparing(o -> tickMap.get(o)).reversed())
+        .collect(Collectors.toList());
+  }
+
+  public void setSpeed(final String speedName) {
+    clock.startTicking(tickMap.get(speedName));
+  }
+
+  public void tick() {
+    clock.tick();
+  }
+
+  public void stop() {
+    clock.stop();
+  }
+}

--- a/src/main/java/com/holub/system/TickSystem.java
+++ b/src/main/java/com/holub/system/TickSystem.java
@@ -1,14 +1,19 @@
 package com.holub.system;
 
+import com.holub.tools.Observable;
+import com.holub.tools.Observer;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
-public class TickSystem {
+public class TickSystem implements Observable {
   final Clock clock;
+  String currentSpeed;
   Map<String, Integer> tickMap;
+  List<Observer> observers;
   /**
    *
    */
@@ -32,6 +37,8 @@ public class TickSystem {
   public TickSystem(final Clock c) {
     clock = c;
     tickMap = new HashMap<>();
+    observers = new LinkedList<>();
+    currentSpeed = "Halt";
     tickMap.put("Agonizing", AGONIZING_MS); // agonizing
     tickMap.put("Slow", SLOW_MS); // slow
     tickMap.put("Medium", MEDIUM_MS); // medium
@@ -44,8 +51,14 @@ public class TickSystem {
         .collect(Collectors.toList());
   }
 
+  public String getSpeed() {
+    return currentSpeed;
+  }
+
   public void setSpeed(final String speedName) {
+    currentSpeed = speedName;
     clock.startTicking(tickMap.get(speedName));
+    update();
   }
 
   public void tick() {
@@ -53,6 +66,26 @@ public class TickSystem {
   }
 
   public void stop() {
+    currentSpeed = "Halt";
     clock.stop();
+    update();
+  }
+
+  @Override
+  public void update() {
+    for (Observer observer : observers) {
+      observer.detectUpdate(this);
+    }
+  }
+
+  @Override
+  public void attach(Observer observer) {
+    observers.add(observer);
+    update();
+  }
+
+  @Override
+  public void detach(Observer observer) {
+    observers.remove(observer);
   }
 }

--- a/src/main/java/com/holub/ui/StatusBar.java
+++ b/src/main/java/com/holub/ui/StatusBar.java
@@ -1,0 +1,27 @@
+package com.holub.ui;
+
+import com.holub.system.TickSystem;
+import com.holub.tools.Observable;
+import com.holub.tools.Observer;
+import java.awt.Dimension;
+import javax.swing.JLabel;
+
+public class StatusBar extends JLabel implements Observer {
+  public StatusBar() {
+    super();
+    super.setPreferredSize(new Dimension(100, 16));
+    setMessage("Ready");
+  }
+
+  public void setMessage(String message) {
+    setText(" "+message);
+  }
+
+  @Override
+  public void detectUpdate(Observable o) {
+    if (o instanceof TickSystem) {
+      TickSystem tickSystem = (TickSystem) o;
+      setMessage(tickSystem.getSpeed());
+    }
+  }
+}

--- a/src/main/java/com/holub/ui/menu/ClockMenuItem.java
+++ b/src/main/java/com/holub/ui/menu/ClockMenuItem.java
@@ -1,40 +1,16 @@
 package com.holub.ui.menu;
 
 import com.holub.system.Clock;
+import com.holub.system.TickSystem;
 import java.awt.event.ActionListener;
 import java.util.HashMap;
 import java.util.Map;
 import javax.swing.JMenuItem;
+import lombok.RequiredArgsConstructor;
 
+@RequiredArgsConstructor
 public class ClockMenuItem implements MenuItem {
-
-  /**
-   *
-   */
-  private static final int AGONIZING_MS = 500;
-  /**
-   *
-   */
-  private static final int SLOW_MS = 150;
-  /**
-   *
-   */
-  private static final int MEDIUM_MS = 70;
-  /**
-   *
-   */
-  private static final int FAST_MS = 30;
-  /**
-   *
-   */
-  private Clock clock;
-
-  /**
-   * @param c
-   */
-  public ClockMenuItem(final Clock c) {
-    this.clock = c;
-  }
+  final TickSystem tickSystem;
 
   /**
    * Create the menu that controls the clock speed and put it onto the menu
@@ -45,31 +21,10 @@ public class ClockMenuItem implements MenuItem {
   public void register(final MenuSite menuSite) {
     // First set up a single listener that will handle all the
     // menu-selection events except "Exit"
-
-    ActionListener modifier = e -> {
-      String name = ((JMenuItem) e.getSource()).getName();
-      char toDo = name.charAt(0);
-
-      if (toDo == 'T') {
-        clock.tick();              // single tick
-      } else {
-        Map<Character, Integer> tickMap = new HashMap<>();
-        tickMap.put('A', AGONIZING_MS); // agonizing
-        tickMap.put('S', SLOW_MS); // slow
-        tickMap.put('M', MEDIUM_MS); // medium
-        tickMap.put('F', FAST_MS); // fast
-        Integer speed = tickMap.get(toDo);
-        if (speed == null) {
-          speed = 0;
-        }
-        clock.startTicking(speed); // fast
-      }
-    };
-    menuSite.addLine(this, "Go", "Halt", modifier);
-    menuSite.addLine(this, "Go", "Tick (Single Step)", modifier);
-    menuSite.addLine(this, "Go", "Agonizing", modifier);
-    menuSite.addLine(this, "Go", "Slow", modifier);
-    menuSite.addLine(this, "Go", "Medium", modifier);
-    menuSite.addLine(this, "Go", "Fast", modifier);
+    menuSite.addLine(this, "Go", "Halt", e -> { tickSystem.stop(); });
+    menuSite.addLine(this, "Go", "Tick (Single Step)", e-> { tickSystem.tick();});
+    for (String speedName : tickSystem.getSupportedSpeeds()) {
+      menuSite.addLine(this, "Go", speedName, e->{tickSystem.setSpeed(((JMenuItem)e.getSource()).getName());});
+    }
   }
 }


### PR DESCRIPTION
- Closes #50 

- 아래와 같이 현재 스피드가 나오도록 하단에 status bar 를 추가합니다.
- 이를 위해서 아래와 같이 개념이 분리되었습니다.:
  - `Clock` : 현실 시간과 tick 을 이어주는 시계 객체, tick 을 전파하기 위해서만 존재하며, 어떠한 상태도 들고 있지 않습니다. 오로지 Clock 을 바라보는 객체들에게 tick 을 전파만 합니다.
  - `TickSystem` : Clock 을 제어하기 위한 객체이며, `Clock` 에 관한 유틸함수들을 제공해줍니다. 현재 speed 상태를 가지고 있으며, 지원하는 스피드 목록을 가지고 있습니다.
  - `Statusbar` : 하단에 상태를 표기해주는 객체이며, `TickSystem` 을 observe 하고 있습니다.


<img width="511" alt="image" src="https://user-images.githubusercontent.com/17357596/205429895-97a85071-4613-47cf-9479-99d07cf23da5.png">


- 추가된 사항 이외의 refactoring 사항 : `ClockMenuItem` 에서 지원하는 스피드 목록을 들고 있었으나, 이 부분이 `TickSystem` 으로 빠지게 되면서, 단순화 되었고, 정말 UI 의 기능만을 가지게 되었습니다. 
